### PR TITLE
Add b:clrzr_exempt escape hatch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ you are not seeing the colors, add the following lines to your `vimrc` and resta
 Sometimes, `cursorline` obscures the highlights added by `clrzr`.  Disable it to see
 colors as you type them.  Very useful in combination with `CTRL-A` and `CTRL-X` (increment & decrement)!
 
+### Compatibility Escape Hatch
+
+Some languages don't make common use of color codes but have constructs that could appear to be color codes.
+Notably the C and C++ preprocessor `#define` can have the `#def` prefix interpreted as a hex color. To exempt
+a file from clrzr highlighting you can set a buffer local variable.
+
+```vim
+   " probably best in .vim/ftplugin/<filetype>.vim
+   let b:clrzr_exempt = v:true
+```
+
 ### Origin
 
 This version is based on https://github.com/lilydjwg/colorizer, also found as

--- a/autoload/clrzr.vim
+++ b/autoload/clrzr.vim
@@ -19,7 +19,6 @@ set cpo&vim
 " - multi-line insert (check textprop count)
 " - awk vs unicode.  (line2byte, byte2line?)
 " - change colors, or enable/disable, with two views into same buffer to reproduce E966
-" TODO: allowed filetypes list?
 " TODO: sign_column (bigger pls, :h sign-commands)?
 " TODO: color change operation
 
@@ -512,14 +511,18 @@ endfunction
 function! clrzr#RefreshAllBuffers()
   let bufs = getbufinfo()
   for d_buf in bufs
-    call s:RebuildTextProps(d_buf, 1, d_buf.linecount)
+    if !get(d_buf.variables, "clrzr_exempt", v:false)
+      call s:RebuildTextProps(d_buf, 1, d_buf.linecount)
+    endif
   endfor
 endfunction
 
 
 function! clrzr#Refresh()
   let [d_buf] = getbufinfo(bufnr())
-  call s:RebuildTextProps(d_buf, 1, d_buf.linecount)
+  if !get(d_buf.variables, "clrzr_exempt", v:false)
+    call s:RebuildTextProps(d_buf, 1, d_buf.linecount)
+  endif
 endfunction
 
 

--- a/doc/clrzr.txt
+++ b/doc/clrzr.txt
@@ -49,5 +49,11 @@ Note: if you modify a color string in normal mode, if the cursor is still on
 that line, it'll take 'updatetime' seconds to update. You can use
 :ClrzrRefresh (or your key mapping) again to force update.
 
+                                                          *'b:clrzr_exempt'*
+If you would like to disable Clrzr on a single buffer, you can set a
+buffer-local variable like so:
+
+  let b:clrzr_exempt = v:true
+
 ===============================================================================
 vim:ft=help:et:ts=2:sw=2:sts=2:norl


### PR DESCRIPTION
See the README/doc updates for the motivation for this change.