### PR TITLE
Revert "Require colors to start at a new word"

### DIFF
--- a/autoload/clrzr.awk
+++ b/autoload/clrzr.awk
@@ -11,11 +11,11 @@ BEGIN {
 	cma = rSpc "," rSpc
 
 	rExpr = "(" \
-		"(\\<0x|#)(" rHex "{8}|" rHex "{6}|" rHex "{4}|" rHex "{3})\\>" \
+		"(0x|#)(" rHex "{8}|" rHex "{6}|" rHex "{4}|" rHex "{3})" \
 		"|" \
-		"(\\<rgb|\\<rgba)\\(" rSpc rFltOrPct cma rFltOrPct cma rFltOrPct "(" cma rFltOrPct ")?" rSpc "\\)" \
+		"(rgb|rgba)\\(" rSpc rFltOrPct cma rFltOrPct cma rFltOrPct "(" cma rFltOrPct ")?" rSpc "\\)" \
 		"|" \
-		"(\\<hsl|\\<hsla)\\(" rSpc rFlt cma rPct cma rPct "(" cma rFltOrPct ")?" rSpc "\\)" \
+		"(hsl|hsla)\\(" rSpc rFlt cma rPct cma rPct "(" cma rFltOrPct ")?" rSpc "\\)" \
 	")"
 
 	rNumPfx = "^" rSpc "[0-9]+\t"


### PR DESCRIPTION
Reverts BourgeoisBear/clrzr#2

GNU awk doesn't understand these patterns.